### PR TITLE
Nuke rooms locally

### DIFF
--- a/next-app/app/chat/[room_id]/page.tsx
+++ b/next-app/app/chat/[room_id]/page.tsx
@@ -66,7 +66,7 @@ export default function RoomPage() {
             saveToStorage(LOCAL_STORAGE_KEYS.BACKUP_WAS_DB_MIGRATED_JSON_SQLITE_V1, currentStoredRooms)
             clearStorage(LOCAL_STORAGE_KEYS.ROOMS)
             saveToStorage(LOCAL_STORAGE_KEYS.WAS_DB_MIGRATED_JSON_SQLITE_V1, "true")
-            window.location.reload()
+            window.location.replace('/')
         }
     }, [])
     

--- a/next-app/app/chat/[room_id]/page.tsx
+++ b/next-app/app/chat/[room_id]/page.tsx
@@ -3,7 +3,7 @@
 import { useParams, useRouter } from "next/navigation";
 import { useRoomContext } from "./RoomContext";
 import { LOCAL_STORAGE_KEYS } from "@/app/constants/localStorageKeys";
-import { getFromStorage } from "@/app/lib/localStorage";
+import { clearStorage, getFromStorage, saveToStorage } from "@/app/lib/localStorage";
 import { useEffect, useMemo } from "react";
 import { Room } from "@/app/types";
 import MessageArea from "@/app/components/MessageArea";
@@ -58,6 +58,17 @@ export default function RoomPage() {
             setUser(userData);
         }
     }, [router]);
+
+    useEffect(() => {
+        const wasNukedDueToMigration: string | null = getFromStorage(LOCAL_STORAGE_KEYS.WAS_DB_MIGRATED_JSON_SQLITE_V1)
+        if (wasNukedDueToMigration === null) {
+            const currentStoredRooms = getFromStorage(LOCAL_STORAGE_KEYS.ROOMS)
+            saveToStorage(LOCAL_STORAGE_KEYS.BACKUP_WAS_DB_MIGRATED_JSON_SQLITE_V1, currentStoredRooms)
+            clearStorage(LOCAL_STORAGE_KEYS.ROOMS)
+            saveToStorage(LOCAL_STORAGE_KEYS.WAS_DB_MIGRATED_JSON_SQLITE_V1, "true")
+            window.location.reload()
+        }
+    }, [])
     
     useEffect(() => {
         const doFn = async () => {

--- a/next-app/app/constants/localStorageKeys.ts
+++ b/next-app/app/constants/localStorageKeys.ts
@@ -1,4 +1,6 @@
 export const LOCAL_STORAGE_KEYS = {
     USER: "account-user-object",
     ROOMS: "chat-rooms-list",
+    WAS_DB_MIGRATED_JSON_SQLITE_V1: "was_db_migrated_json_sqlite_v1",
+    BACKUP_WAS_DB_MIGRATED_JSON_SQLITE_V1: "backup_was_db_migrated_json_sqlite_v1"
 }

--- a/next-app/app/page.tsx
+++ b/next-app/app/page.tsx
@@ -23,7 +23,7 @@ export default function Home() {
             saveToStorage(LOCAL_STORAGE_KEYS.BACKUP_WAS_DB_MIGRATED_JSON_SQLITE_V1, currentStoredRooms)
             clearStorage(LOCAL_STORAGE_KEYS.ROOMS)
             saveToStorage(LOCAL_STORAGE_KEYS.WAS_DB_MIGRATED_JSON_SQLITE_V1, "true")
-            window.location.reload()
+            window.location.replace('/')
         }
     }, [])
 

--- a/next-app/app/page.tsx
+++ b/next-app/app/page.tsx
@@ -2,7 +2,7 @@
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { LOCAL_STORAGE_KEYS } from "./constants/localStorageKeys";
-import { getFromStorage } from "./lib/localStorage";
+import { clearStorage, getFromStorage, saveToStorage } from "./lib/localStorage";
 
 export default function Home() {
     const router = useRouter();
@@ -15,6 +15,17 @@ export default function Home() {
             router.push("/auth");
         }
     }, [router]);
+
+    useEffect(() => {
+        const wasNukedDueToMigration: string | null = getFromStorage(LOCAL_STORAGE_KEYS.WAS_DB_MIGRATED_JSON_SQLITE_V1)
+        if (wasNukedDueToMigration === null) {
+            const currentStoredRooms = getFromStorage(LOCAL_STORAGE_KEYS.ROOMS)
+            saveToStorage(LOCAL_STORAGE_KEYS.BACKUP_WAS_DB_MIGRATED_JSON_SQLITE_V1, currentStoredRooms)
+            clearStorage(LOCAL_STORAGE_KEYS.ROOMS)
+            saveToStorage(LOCAL_STORAGE_KEYS.WAS_DB_MIGRATED_JSON_SQLITE_V1, "true")
+            window.location.reload()
+        }
+    }, [])
 
     return null;
 }


### PR DESCRIPTION
Migrating the database system from json to a sqlite on backend in the next PR, so this nukes the rooms config stored locally, because I dont want to migrate data, due to early version of app and minimum usage by users.